### PR TITLE
Replace CLIP monkey-patching with add_object_patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Like any other model patch:
 ![combined_image_new](https://github.com/Extraltodeus/Stable-Diffusion-temperature-settings/assets/15731540/12034834-43d0-44a5-a603-6c87d1bc6e5d)
 
 
-Note: The CLIP temperature patches the attention within the VRAM/RAM on the connected clip model. The modification ignores connections but is only linked to what is loaded. To get default behavior set the temperature at one or reload the model.
-
-
 # Patreon
 
 Provide an incentive to contributors:


### PR DESCRIPTION
While working on [NegPip refactoring](https://github.com/pamparamm/ComfyUI-ppm/blob/master/clip_negpip.py#L99-L107), I've discovered that you can apply all sorts of patches to clip (and unet) internals by using `add_object_patch` function from CLIP class.
This approach should respect node connections and therefore eliminate various possible side-effects.